### PR TITLE
refactor: tabela expenses para centralizar despesas

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -18,6 +18,7 @@ import { Supplies } from './supplies/entities/supplies.entity';
 import { OperationalCostModule } from './operational-cost/operational-cost.module';
 import { OperationalCost } from './operational-cost/entities/operational-cost.entity';
 import { ExpensesModule } from './expenses/expenses.module';
+import { Expense } from './expenses/entities/expense.entity';
 
 @Module({
   imports: [
@@ -38,6 +39,7 @@ import { ExpensesModule } from './expenses/expenses.module';
         UtilityCost,
         Supplies,
         OperationalCost,
+        Expense,
       ],
       synchronize: false,
     }),

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -17,6 +17,7 @@ import { SuppliesModule } from './supplies/supplies.module';
 import { Supplies } from './supplies/entities/supplies.entity';
 import { OperationalCostModule } from './operational-cost/operational-cost.module';
 import { OperationalCost } from './operational-cost/entities/operational-cost.entity';
+import { ExpensesModule } from './expenses/expenses.module';
 
 @Module({
   imports: [
@@ -46,6 +47,7 @@ import { OperationalCost } from './operational-cost/entities/operational-cost.en
     UtilityCostModule,
     SuppliesModule,
     OperationalCostModule,
+    ExpensesModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/database/data-source.ts
+++ b/src/database/data-source.ts
@@ -7,6 +7,7 @@ import { PersonnelCost } from 'src/personnel-cost/entities/personnel-cost.entity
 import { UtilityCost } from 'src/utility-cost/entities/utility-cost.entity';
 import { Supplies } from 'src/supplies/entities/supplies.entity';
 import { OperationalCost } from 'src/operational-cost/entities/operational-cost.entity';
+import { Expense } from 'src/expenses/entities/expense.entity';
 dotenv.config();
 
 export const AppDataSource = new DataSource({
@@ -23,6 +24,7 @@ export const AppDataSource = new DataSource({
     UtilityCost,
     Supplies,
     OperationalCost,
+    Expense,
   ],
   migrations: ['src/database/migrations/*.ts'],
 });

--- a/src/database/migrations/1761510448683-initial-schema.ts
+++ b/src/database/migrations/1761510448683-initial-schema.ts
@@ -18,5 +18,6 @@ export class InitialSchema1761510448683 implements MigrationInterface {
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`DROP TABLE "login_attempts"`);
     await queryRunner.query(`DROP TABLE "users"`);
+    await queryRunner.query(`DROP TYPE "public"."users_role_enum"`);
   }
 }

--- a/src/database/migrations/1761511082373-personnel-cost-schema.ts
+++ b/src/database/migrations/1761511082373-personnel-cost-schema.ts
@@ -14,5 +14,6 @@ export class PersonnelCostSchema1761511082373 implements MigrationInterface {
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`DROP TABLE "personnel_cost"`);
+    await queryRunner.query(`DROP TYPE "public"."personnel_cost_type_enum"`);
   }
 }

--- a/src/database/migrations/1762152864017-expenses-schema.ts
+++ b/src/database/migrations/1762152864017-expenses-schema.ts
@@ -1,0 +1,46 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class ExpensesSchema1762152864017 implements MigrationInterface {
+    name = 'ExpensesSchema1762152864017'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TYPE "public"."expenses_category_enum" AS ENUM('PERSONNEL', 'UTILITY', 'SUPPLIES', 'OPERATIONAL')`);
+        await queryRunner.query(`CREATE TABLE "expenses" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "category" "public"."expenses_category_enum" NOT NULL, CONSTRAINT "PK_94c3ceb17e3140abc9282c20610" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`ALTER TABLE "personnel_cost" ADD "expenseId" uuid`);
+        await queryRunner.query(`ALTER TABLE "personnel_cost" ADD CONSTRAINT "UQ_bf5317bc0626f1a1889adefc683" UNIQUE ("expenseId")`);
+        await queryRunner.query(`ALTER TABLE "utility_cost" ADD "expenseId" uuid`);
+        await queryRunner.query(`ALTER TABLE "utility_cost" ADD CONSTRAINT "UQ_c6722fc568ad3e7386a8b81b246" UNIQUE ("expenseId")`);
+        await queryRunner.query(`ALTER TABLE "supplies" ADD "expenseId" uuid`);
+        await queryRunner.query(`ALTER TABLE "supplies" ADD CONSTRAINT "UQ_7173318bb9619ce069f56d79489" UNIQUE ("expenseId")`);
+        await queryRunner.query(`ALTER TABLE "operational-cost" ADD "expenseId" uuid`);
+        await queryRunner.query(`ALTER TABLE "operational-cost" ADD CONSTRAINT "UQ_716e6544ba5ba9a06c621dd699e" UNIQUE ("expenseId")`);
+        await queryRunner.query(`ALTER TABLE "operational-cost" DROP COLUMN "date"`);
+        await queryRunner.query(`ALTER TABLE "operational-cost" ADD "date" date NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "operational-cost" ALTER COLUMN "description" SET NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "personnel_cost" ADD CONSTRAINT "FK_bf5317bc0626f1a1889adefc683" FOREIGN KEY ("expenseId") REFERENCES "expenses"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "utility_cost" ADD CONSTRAINT "FK_c6722fc568ad3e7386a8b81b246" FOREIGN KEY ("expenseId") REFERENCES "expenses"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "supplies" ADD CONSTRAINT "FK_7173318bb9619ce069f56d79489" FOREIGN KEY ("expenseId") REFERENCES "expenses"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "operational-cost" ADD CONSTRAINT "FK_716e6544ba5ba9a06c621dd699e" FOREIGN KEY ("expenseId") REFERENCES "expenses"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "operational-cost" DROP CONSTRAINT "FK_716e6544ba5ba9a06c621dd699e"`);
+        await queryRunner.query(`ALTER TABLE "supplies" DROP CONSTRAINT "FK_7173318bb9619ce069f56d79489"`);
+        await queryRunner.query(`ALTER TABLE "utility_cost" DROP CONSTRAINT "FK_c6722fc568ad3e7386a8b81b246"`);
+        await queryRunner.query(`ALTER TABLE "personnel_cost" DROP CONSTRAINT "FK_bf5317bc0626f1a1889adefc683"`);
+        await queryRunner.query(`ALTER TABLE "operational-cost" ALTER COLUMN "description" DROP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "operational-cost" DROP COLUMN "date"`);
+        await queryRunner.query(`ALTER TABLE "operational-cost" ADD "date" TIME NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "operational-cost" DROP CONSTRAINT "UQ_716e6544ba5ba9a06c621dd699e"`);
+        await queryRunner.query(`ALTER TABLE "operational-cost" DROP COLUMN "expenseId"`);
+        await queryRunner.query(`ALTER TABLE "supplies" DROP CONSTRAINT "UQ_7173318bb9619ce069f56d79489"`);
+        await queryRunner.query(`ALTER TABLE "supplies" DROP COLUMN "expenseId"`);
+        await queryRunner.query(`ALTER TABLE "utility_cost" DROP CONSTRAINT "UQ_c6722fc568ad3e7386a8b81b246"`);
+        await queryRunner.query(`ALTER TABLE "utility_cost" DROP COLUMN "expenseId"`);
+        await queryRunner.query(`ALTER TABLE "personnel_cost" DROP CONSTRAINT "UQ_bf5317bc0626f1a1889adefc683"`);
+        await queryRunner.query(`ALTER TABLE "personnel_cost" DROP COLUMN "expenseId"`);
+        await queryRunner.query(`DROP TABLE "expenses"`);
+        await queryRunner.query(`DROP TYPE "public"."expenses_category_enum"`);
+    }
+
+}

--- a/src/database/migrations/1762180100951-expenses-schema.ts
+++ b/src/database/migrations/1762180100951-expenses-schema.ts
@@ -1,11 +1,19 @@
 import { MigrationInterface, QueryRunner } from "typeorm";
 
-export class ExpensesSchema1762152864017 implements MigrationInterface {
-    name = 'ExpensesSchema1762152864017'
+export class ExpensesSchema1762180100951 implements MigrationInterface {
+    name = 'ExpensesSchema1762180100951'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`CREATE TYPE "public"."expenses_category_enum" AS ENUM('PERSONNEL', 'UTILITY', 'SUPPLIES', 'OPERATIONAL')`);
-        await queryRunner.query(`CREATE TABLE "expenses" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "category" "public"."expenses_category_enum" NOT NULL, CONSTRAINT "PK_94c3ceb17e3140abc9282c20610" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE TABLE "expenses" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "date" date NOT NULL, "value" numeric(12,2) NOT NULL, "category" "public"."expenses_category_enum" NOT NULL, CONSTRAINT "PK_94c3ceb17e3140abc9282c20610" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`ALTER TABLE "personnel_cost" DROP COLUMN "date"`);
+        await queryRunner.query(`ALTER TABLE "personnel_cost" DROP COLUMN "value"`);
+        await queryRunner.query(`ALTER TABLE "utility_cost" DROP COLUMN "date"`);
+        await queryRunner.query(`ALTER TABLE "utility_cost" DROP COLUMN "value"`);
+        await queryRunner.query(`ALTER TABLE "supplies" DROP COLUMN "date"`);
+        await queryRunner.query(`ALTER TABLE "supplies" DROP COLUMN "total_cost"`);
+        await queryRunner.query(`ALTER TABLE "operational-cost" DROP COLUMN "value"`);
+        await queryRunner.query(`ALTER TABLE "operational-cost" DROP COLUMN "date"`);
         await queryRunner.query(`ALTER TABLE "personnel_cost" ADD "expenseId" uuid`);
         await queryRunner.query(`ALTER TABLE "personnel_cost" ADD CONSTRAINT "UQ_bf5317bc0626f1a1889adefc683" UNIQUE ("expenseId")`);
         await queryRunner.query(`ALTER TABLE "utility_cost" ADD "expenseId" uuid`);
@@ -14,9 +22,6 @@ export class ExpensesSchema1762152864017 implements MigrationInterface {
         await queryRunner.query(`ALTER TABLE "supplies" ADD CONSTRAINT "UQ_7173318bb9619ce069f56d79489" UNIQUE ("expenseId")`);
         await queryRunner.query(`ALTER TABLE "operational-cost" ADD "expenseId" uuid`);
         await queryRunner.query(`ALTER TABLE "operational-cost" ADD CONSTRAINT "UQ_716e6544ba5ba9a06c621dd699e" UNIQUE ("expenseId")`);
-        await queryRunner.query(`ALTER TABLE "operational-cost" DROP COLUMN "date"`);
-        await queryRunner.query(`ALTER TABLE "operational-cost" ADD "date" date NOT NULL`);
-        await queryRunner.query(`ALTER TABLE "operational-cost" ALTER COLUMN "description" SET NOT NULL`);
         await queryRunner.query(`ALTER TABLE "personnel_cost" ADD CONSTRAINT "FK_bf5317bc0626f1a1889adefc683" FOREIGN KEY ("expenseId") REFERENCES "expenses"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
         await queryRunner.query(`ALTER TABLE "utility_cost" ADD CONSTRAINT "FK_c6722fc568ad3e7386a8b81b246" FOREIGN KEY ("expenseId") REFERENCES "expenses"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
         await queryRunner.query(`ALTER TABLE "supplies" ADD CONSTRAINT "FK_7173318bb9619ce069f56d79489" FOREIGN KEY ("expenseId") REFERENCES "expenses"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
@@ -28,9 +33,6 @@ export class ExpensesSchema1762152864017 implements MigrationInterface {
         await queryRunner.query(`ALTER TABLE "supplies" DROP CONSTRAINT "FK_7173318bb9619ce069f56d79489"`);
         await queryRunner.query(`ALTER TABLE "utility_cost" DROP CONSTRAINT "FK_c6722fc568ad3e7386a8b81b246"`);
         await queryRunner.query(`ALTER TABLE "personnel_cost" DROP CONSTRAINT "FK_bf5317bc0626f1a1889adefc683"`);
-        await queryRunner.query(`ALTER TABLE "operational-cost" ALTER COLUMN "description" DROP NOT NULL`);
-        await queryRunner.query(`ALTER TABLE "operational-cost" DROP COLUMN "date"`);
-        await queryRunner.query(`ALTER TABLE "operational-cost" ADD "date" TIME NOT NULL`);
         await queryRunner.query(`ALTER TABLE "operational-cost" DROP CONSTRAINT "UQ_716e6544ba5ba9a06c621dd699e"`);
         await queryRunner.query(`ALTER TABLE "operational-cost" DROP COLUMN "expenseId"`);
         await queryRunner.query(`ALTER TABLE "supplies" DROP CONSTRAINT "UQ_7173318bb9619ce069f56d79489"`);
@@ -39,6 +41,14 @@ export class ExpensesSchema1762152864017 implements MigrationInterface {
         await queryRunner.query(`ALTER TABLE "utility_cost" DROP COLUMN "expenseId"`);
         await queryRunner.query(`ALTER TABLE "personnel_cost" DROP CONSTRAINT "UQ_bf5317bc0626f1a1889adefc683"`);
         await queryRunner.query(`ALTER TABLE "personnel_cost" DROP COLUMN "expenseId"`);
+        await queryRunner.query(`ALTER TABLE "operational-cost" ADD "date" date NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "operational-cost" ADD "value" numeric(12,2) NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "supplies" ADD "total_cost" numeric(10,2) NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "supplies" ADD "date" date NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "utility_cost" ADD "value" numeric(12,2) NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "utility_cost" ADD "date" date NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "personnel_cost" ADD "value" numeric(12,2) NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "personnel_cost" ADD "date" date NOT NULL`);
         await queryRunner.query(`DROP TABLE "expenses"`);
         await queryRunner.query(`DROP TYPE "public"."expenses_category_enum"`);
     }

--- a/src/database/migrations/1762191892708-update-expenses-entities.ts
+++ b/src/database/migrations/1762191892708-update-expenses-entities.ts
@@ -1,0 +1,36 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class UpdateExpensesEntities1762191892708 implements MigrationInterface {
+    name = 'UpdateExpensesEntities1762191892708'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "personnel_cost" DROP CONSTRAINT "FK_bf5317bc0626f1a1889adefc683"`);
+        await queryRunner.query(`ALTER TABLE "personnel_cost" ALTER COLUMN "expenseId" SET NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "utility_cost" DROP CONSTRAINT "FK_c6722fc568ad3e7386a8b81b246"`);
+        await queryRunner.query(`ALTER TABLE "utility_cost" ALTER COLUMN "expenseId" SET NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "supplies" DROP CONSTRAINT "FK_7173318bb9619ce069f56d79489"`);
+        await queryRunner.query(`ALTER TABLE "supplies" ALTER COLUMN "expenseId" SET NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "operational-cost" DROP CONSTRAINT "FK_716e6544ba5ba9a06c621dd699e"`);
+        await queryRunner.query(`ALTER TABLE "operational-cost" ALTER COLUMN "expenseId" SET NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "personnel_cost" ADD CONSTRAINT "FK_bf5317bc0626f1a1889adefc683" FOREIGN KEY ("expenseId") REFERENCES "expenses"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "utility_cost" ADD CONSTRAINT "FK_c6722fc568ad3e7386a8b81b246" FOREIGN KEY ("expenseId") REFERENCES "expenses"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "supplies" ADD CONSTRAINT "FK_7173318bb9619ce069f56d79489" FOREIGN KEY ("expenseId") REFERENCES "expenses"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "operational-cost" ADD CONSTRAINT "FK_716e6544ba5ba9a06c621dd699e" FOREIGN KEY ("expenseId") REFERENCES "expenses"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "operational-cost" DROP CONSTRAINT "FK_716e6544ba5ba9a06c621dd699e"`);
+        await queryRunner.query(`ALTER TABLE "supplies" DROP CONSTRAINT "FK_7173318bb9619ce069f56d79489"`);
+        await queryRunner.query(`ALTER TABLE "utility_cost" DROP CONSTRAINT "FK_c6722fc568ad3e7386a8b81b246"`);
+        await queryRunner.query(`ALTER TABLE "personnel_cost" DROP CONSTRAINT "FK_bf5317bc0626f1a1889adefc683"`);
+        await queryRunner.query(`ALTER TABLE "operational-cost" ALTER COLUMN "expenseId" DROP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "operational-cost" ADD CONSTRAINT "FK_716e6544ba5ba9a06c621dd699e" FOREIGN KEY ("expenseId") REFERENCES "expenses"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "supplies" ALTER COLUMN "expenseId" DROP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "supplies" ADD CONSTRAINT "FK_7173318bb9619ce069f56d79489" FOREIGN KEY ("expenseId") REFERENCES "expenses"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "utility_cost" ALTER COLUMN "expenseId" DROP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "utility_cost" ADD CONSTRAINT "FK_c6722fc568ad3e7386a8b81b246" FOREIGN KEY ("expenseId") REFERENCES "expenses"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "personnel_cost" ALTER COLUMN "expenseId" DROP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "personnel_cost" ADD CONSTRAINT "FK_bf5317bc0626f1a1889adefc683" FOREIGN KEY ("expenseId") REFERENCES "expenses"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+}

--- a/src/database/migrations/1762231691665-cascade-expenses.ts
+++ b/src/database/migrations/1762231691665-cascade-expenses.ts
@@ -1,0 +1,28 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class CascadeExpenses1762231691665 implements MigrationInterface {
+    name = 'CascadeExpenses1762231691665'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "personnel_cost" DROP CONSTRAINT "FK_bf5317bc0626f1a1889adefc683"`);
+        await queryRunner.query(`ALTER TABLE "utility_cost" DROP CONSTRAINT "FK_c6722fc568ad3e7386a8b81b246"`);
+        await queryRunner.query(`ALTER TABLE "supplies" DROP CONSTRAINT "FK_7173318bb9619ce069f56d79489"`);
+        await queryRunner.query(`ALTER TABLE "operational-cost" DROP CONSTRAINT "FK_716e6544ba5ba9a06c621dd699e"`);
+        await queryRunner.query(`ALTER TABLE "personnel_cost" ADD CONSTRAINT "FK_bf5317bc0626f1a1889adefc683" FOREIGN KEY ("expenseId") REFERENCES "expenses"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "utility_cost" ADD CONSTRAINT "FK_c6722fc568ad3e7386a8b81b246" FOREIGN KEY ("expenseId") REFERENCES "expenses"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "supplies" ADD CONSTRAINT "FK_7173318bb9619ce069f56d79489" FOREIGN KEY ("expenseId") REFERENCES "expenses"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "operational-cost" ADD CONSTRAINT "FK_716e6544ba5ba9a06c621dd699e" FOREIGN KEY ("expenseId") REFERENCES "expenses"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "operational-cost" DROP CONSTRAINT "FK_716e6544ba5ba9a06c621dd699e"`);
+        await queryRunner.query(`ALTER TABLE "supplies" DROP CONSTRAINT "FK_7173318bb9619ce069f56d79489"`);
+        await queryRunner.query(`ALTER TABLE "utility_cost" DROP CONSTRAINT "FK_c6722fc568ad3e7386a8b81b246"`);
+        await queryRunner.query(`ALTER TABLE "personnel_cost" DROP CONSTRAINT "FK_bf5317bc0626f1a1889adefc683"`);
+        await queryRunner.query(`ALTER TABLE "operational-cost" ADD CONSTRAINT "FK_716e6544ba5ba9a06c621dd699e" FOREIGN KEY ("expenseId") REFERENCES "expenses"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "supplies" ADD CONSTRAINT "FK_7173318bb9619ce069f56d79489" FOREIGN KEY ("expenseId") REFERENCES "expenses"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "utility_cost" ADD CONSTRAINT "FK_c6722fc568ad3e7386a8b81b246" FOREIGN KEY ("expenseId") REFERENCES "expenses"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "personnel_cost" ADD CONSTRAINT "FK_bf5317bc0626f1a1889adefc683" FOREIGN KEY ("expenseId") REFERENCES "expenses"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+}

--- a/src/expenses/entities/expense.entity.ts
+++ b/src/expenses/entities/expense.entity.ts
@@ -1,0 +1,15 @@
+import {
+  Column,
+  Entity,
+  PrimaryGeneratedColumn,
+  TableInheritance,
+} from 'typeorm';
+import { ExpenseType } from '../enums/expense-type.enum';
+
+@Entity('expenses')
+export class Expense {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+  @Column({ type: 'enum', enum: ExpenseType })
+  category: ExpenseType;
+}

--- a/src/expenses/entities/expense.entity.ts
+++ b/src/expenses/entities/expense.entity.ts
@@ -10,6 +10,13 @@ import { ExpenseType } from '../enums/expense-type.enum';
 export class Expense {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @Column({ type: 'date' })
+  date: Date;
+
+  @Column({ type: 'decimal', precision: 12, scale: 2 })
+  value: number;
+
   @Column({ type: 'enum', enum: ExpenseType })
   category: ExpenseType;
 }

--- a/src/expenses/enums/expense-type.enum.ts
+++ b/src/expenses/enums/expense-type.enum.ts
@@ -1,0 +1,6 @@
+export enum ExpenseType {
+  PERSONNEL = 'PERSONNEL',
+  UTILITY = 'UTILITY',
+  SUPPLIES = 'SUPPLIES',
+  OPERATIONAL = 'OPERATIONAL',
+}

--- a/src/expenses/expenses.controller.ts
+++ b/src/expenses/expenses.controller.ts
@@ -1,0 +1,7 @@
+import { Controller } from '@nestjs/common';
+import { ExpensesService } from './expenses.service';
+
+@Controller('expenses')
+export class ExpensesController {
+  constructor(private readonly expensesService: ExpensesService) {}
+}

--- a/src/expenses/expenses.module.ts
+++ b/src/expenses/expenses.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ExpensesService } from './expenses.service';
+import { ExpensesController } from './expenses.controller';
+
+@Module({
+  controllers: [ExpensesController],
+  providers: [ExpensesService],
+})
+export class ExpensesModule {}

--- a/src/expenses/expenses.module.ts
+++ b/src/expenses/expenses.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
 import { ExpensesService } from './expenses.service';
 import { ExpensesController } from './expenses.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Expense } from './entities/expense.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Expense])],
   controllers: [ExpensesController],
   providers: [ExpensesService],
 })

--- a/src/expenses/expenses.module.ts
+++ b/src/expenses/expenses.module.ts
@@ -8,5 +8,6 @@ import { Expense } from './entities/expense.entity';
   imports: [TypeOrmModule.forFeature([Expense])],
   controllers: [ExpensesController],
   providers: [ExpensesService],
+  exports: [ExpensesService],
 })
 export class ExpensesModule {}

--- a/src/expenses/expenses.service.ts
+++ b/src/expenses/expenses.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class ExpensesService {}

--- a/src/expenses/expenses.service.ts
+++ b/src/expenses/expenses.service.ts
@@ -1,4 +1,32 @@
-import { Injectable } from '@nestjs/common';
+import {
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Expense } from './entities/expense.entity';
+import { Repository } from 'typeorm';
 
 @Injectable()
-export class ExpensesService {}
+export class ExpensesService {
+  private logger = new Logger(ExpensesService.name);
+  constructor(
+    @InjectRepository(Expense)
+    private readonly expenseRepository: Repository<Expense>,
+  ) {}
+
+  async delete(id: string) {
+    try {
+      await this.expenseRepository.delete(id);
+    } catch (error) {
+      this.logger.error(error.message);
+
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+
+      throw new InternalServerErrorException(error.message);
+    }
+  }
+}

--- a/src/operational-cost/dtos/register-operational-cost.dto.ts
+++ b/src/operational-cost/dtos/register-operational-cost.dto.ts
@@ -1,11 +1,13 @@
 import {
   IsDateString,
-  IsDecimal,
   IsEnum,
   IsNotEmpty,
+  IsNumber,
   IsString,
+  Min,
 } from 'class-validator';
 import { CostType } from '../enums/operational-cost.enum';
+import { Type } from 'class-transformer';
 
 export class RegisterOperationalCostDto {
   @IsEnum(CostType)
@@ -14,11 +16,13 @@ export class RegisterOperationalCostDto {
 
   @IsDateString()
   @IsNotEmpty()
-  date: string;
+  date: Date;
 
-  @IsDecimal({ decimal_digits: '2' })
+  @Type(() => Number)
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0)
   @IsNotEmpty()
-  value: string;
+  value: number;
 
   @IsString()
   @IsNotEmpty()

--- a/src/operational-cost/dtos/update-operational-cost.dto.ts
+++ b/src/operational-cost/dtos/update-operational-cost.dto.ts
@@ -2,10 +2,13 @@ import {
   IsDateString,
   IsDecimal,
   IsEnum,
+  IsNumber,
   IsOptional,
   IsString,
+  Min,
 } from 'class-validator';
 import { CostType } from '../enums/operational-cost.enum';
+import { Type } from 'class-transformer';
 
 export class UpdateOperationalCostDto {
   @IsEnum(CostType)
@@ -14,11 +17,13 @@ export class UpdateOperationalCostDto {
 
   @IsDateString()
   @IsOptional()
-  date?: string;
+  date?: Date;
 
-  @IsDecimal({ decimal_digits: '2' })
+  @Type(() => Number)
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0)
   @IsOptional()
-  value?: string;
+  value?: number;
 
   @IsString()
   @IsOptional()

--- a/src/operational-cost/entities/operational-cost.entity.ts
+++ b/src/operational-cost/entities/operational-cost.entity.ts
@@ -20,12 +20,6 @@ export class OperationalCost {
   @Column({ type: 'enum', enum: CostType })
   type: CostType;
 
-  @Column({ type: 'date', nullable: false })
-  date: Date;
-
-  @Column({ type: 'decimal', precision: 12, scale: 2, nullable: false })
-  value: string;
-
   @Column({ type: 'text' })
   description: string;
 }

--- a/src/operational-cost/entities/operational-cost.entity.ts
+++ b/src/operational-cost/entities/operational-cost.entity.ts
@@ -13,7 +13,11 @@ export class OperationalCost {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
-  @OneToOne(() => Expense, { cascade: true, nullable: false })
+  @OneToOne(() => Expense, {
+    cascade: true,
+    onDelete: 'CASCADE',
+    nullable: false,
+  })
   @JoinColumn()
   expense: Expense;
 

--- a/src/operational-cost/entities/operational-cost.entity.ts
+++ b/src/operational-cost/entities/operational-cost.entity.ts
@@ -13,7 +13,7 @@ export class OperationalCost {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
-  @OneToOne(() => Expense, { cascade: true })
+  @OneToOne(() => Expense, { cascade: true, nullable: false })
   @JoinColumn()
   expense: Expense;
 

--- a/src/operational-cost/entities/operational-cost.entity.ts
+++ b/src/operational-cost/entities/operational-cost.entity.ts
@@ -1,10 +1,21 @@
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  OneToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 import { CostType } from '../enums/operational-cost.enum';
+import { Expense } from 'src/expenses/entities/expense.entity';
 
 @Entity('operational-cost')
 export class OperationalCost {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @OneToOne(() => Expense, { cascade: true })
+  @JoinColumn()
+  expense: Expense;
 
   @Column({ type: 'enum', enum: CostType })
   type: CostType;

--- a/src/operational-cost/operational-cost.controller.ts
+++ b/src/operational-cost/operational-cost.controller.ts
@@ -41,7 +41,7 @@ export class OperationalCostController {
     return await this.operationalCostService.findAll(filters);
   }
 
-  @Get('id')
+  @Get(':id')
   async findById(@Param('id', new ParseUUIDPipe()) id: string) {
     return await this.operationalCostService.findById(id);
   }

--- a/src/operational-cost/operational-cost.module.ts
+++ b/src/operational-cost/operational-cost.module.ts
@@ -3,9 +3,10 @@ import { OperationalCostController } from './operational-cost.controller';
 import { OperationalCostService } from './operational-cost.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { OperationalCost } from './entities/operational-cost.entity';
+import { ExpensesModule } from 'src/expenses/expenses.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([OperationalCost])],
+  imports: [TypeOrmModule.forFeature([OperationalCost]), ExpensesModule],
   controllers: [OperationalCostController],
   providers: [OperationalCostService],
   exports: [OperationalCostService],

--- a/src/operational-cost/operational-cost.service.ts
+++ b/src/operational-cost/operational-cost.service.ts
@@ -11,6 +11,7 @@ import { RegisterOperationalCostDto } from './dtos/register-operational-cost.dto
 import { OperationalCostFilterDto } from './dtos/operational-cost-filter.dto';
 import { UpdateOperationalCostDto } from './dtos/update-operational-cost.dto';
 import { ExpenseType } from 'src/expenses/enums/expense-type.enum';
+import { ExpensesService } from 'src/expenses/expenses.service';
 
 @Injectable()
 export class OperationalCostService {
@@ -18,6 +19,7 @@ export class OperationalCostService {
   constructor(
     @InjectRepository(OperationalCost)
     private readonly operationalCostRepository: Repository<OperationalCost>,
+    private readonly expensesService: ExpensesService,
   ) {}
 
   async register(registerOperationalCostDto: RegisterOperationalCostDto) {
@@ -164,6 +166,7 @@ export class OperationalCostService {
     try {
       const operationalCost = await this.operationalCostRepository.findOne({
         where: { id },
+        relations: ['expense'],
       });
 
       if (!operationalCost) {
@@ -172,7 +175,7 @@ export class OperationalCostService {
         );
       }
 
-      await this.operationalCostRepository.delete(id);
+      await this.expensesService.delete(operationalCost.expense.id);
       return {
         message: `Custo com operacional id(${id}) deletado com sucesso`,
       };

--- a/src/operational-cost/operational-cost.service.ts
+++ b/src/operational-cost/operational-cost.service.ts
@@ -65,12 +65,12 @@ export class OperationalCostService {
       });
 
     try {
-      const [data, total] = await query
+      const [rows, total] = await query
         .skip((page - 1) * limit)
         .take(limit)
         .getManyAndCount();
 
-      const formattedData = data.map((item) => ({
+      const data = rows.map((item) => ({
         id: item.id,
         type: item.type,
         date: item.expense.date,
@@ -83,7 +83,7 @@ export class OperationalCostService {
         page,
         limit,
         totalPages: Math.ceil(total / limit),
-        formattedData,
+        data,
       };
     } catch (error) {
       this.logger.error(error.message);

--- a/src/personnel-cost/dtos/register-personnel-cost.dto.ts
+++ b/src/personnel-cost/dtos/register-personnel-cost.dto.ts
@@ -21,6 +21,7 @@ export class RegisterPersonnelCostDto {
   @Type(() => Number)
   @IsNumber({ maxDecimalPlaces: 2 })
   @Min(0)
+  @IsNotEmpty()
   value: number;
 
   @IsString()

--- a/src/personnel-cost/dtos/register-personnel-cost.dto.ts
+++ b/src/personnel-cost/dtos/register-personnel-cost.dto.ts
@@ -1,13 +1,13 @@
 import {
   IsDateString,
-  IsDecimal,
   IsEnum,
   IsNotEmpty,
-  IsOptional,
+  IsNumber,
   IsString,
-  Matches,
+  Min,
 } from 'class-validator';
 import { CostType } from '../enums/cost-type.enum';
+import { Type } from 'class-transformer';
 
 export class RegisterPersonnelCostDto {
   @IsEnum(CostType)
@@ -18,8 +18,9 @@ export class RegisterPersonnelCostDto {
   @IsNotEmpty()
   date: Date;
 
-  @IsDecimal({ decimal_digits: '2' })
-  @IsNotEmpty()
+  @Type(() => Number)
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0)
   value: number;
 
   @IsString()

--- a/src/personnel-cost/dtos/register-personnel-cost.dto.ts
+++ b/src/personnel-cost/dtos/register-personnel-cost.dto.ts
@@ -16,11 +16,11 @@ export class RegisterPersonnelCostDto {
 
   @IsDateString()
   @IsNotEmpty()
-  date: string;
+  date: Date;
 
   @IsDecimal({ decimal_digits: '2' })
   @IsNotEmpty()
-  value: string;
+  value: number;
 
   @IsString()
   @IsNotEmpty()

--- a/src/personnel-cost/dtos/update-personnel-cost.dto.ts
+++ b/src/personnel-cost/dtos/update-personnel-cost.dto.ts
@@ -14,11 +14,11 @@ export class UpdatePersonnelCostDto {
 
   @IsDateString()
   @IsOptional()
-  date: string;
+  date: Date;
 
   @IsDecimal({ decimal_digits: '2' })
   @IsOptional()
-  value: string;
+  value: number;
 
   @IsString()
   @IsOptional()

--- a/src/personnel-cost/dtos/update-personnel-cost.dto.ts
+++ b/src/personnel-cost/dtos/update-personnel-cost.dto.ts
@@ -21,6 +21,7 @@ export class UpdatePersonnelCostDto {
   @Type(() => Number)
   @IsNumber({ maxDecimalPlaces: 2 })
   @Min(0)
+  @IsOptional()
   value: number;
 
   @IsString()

--- a/src/personnel-cost/dtos/update-personnel-cost.dto.ts
+++ b/src/personnel-cost/dtos/update-personnel-cost.dto.ts
@@ -1,11 +1,13 @@
 import {
   IsDateString,
-  IsDecimal,
   IsEnum,
+  IsNumber,
   IsOptional,
   IsString,
+  Min,
 } from 'class-validator';
 import { CostType } from '../enums/cost-type.enum';
+import { Type } from 'class-transformer';
 
 export class UpdatePersonnelCostDto {
   @IsEnum(CostType)
@@ -16,8 +18,9 @@ export class UpdatePersonnelCostDto {
   @IsOptional()
   date: Date;
 
-  @IsDecimal({ decimal_digits: '2' })
-  @IsOptional()
+  @Type(() => Number)
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0)
   value: number;
 
   @IsString()

--- a/src/personnel-cost/entities/personnel-cost.entity.ts
+++ b/src/personnel-cost/entities/personnel-cost.entity.ts
@@ -13,7 +13,11 @@ export class PersonnelCost {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
-  @OneToOne(() => Expense, { cascade: true, nullable: false })
+  @OneToOne(() => Expense, {
+    cascade: true,
+    onDelete: 'CASCADE',
+    nullable: false,
+  })
   @JoinColumn()
   expense: Expense;
 

--- a/src/personnel-cost/entities/personnel-cost.entity.ts
+++ b/src/personnel-cost/entities/personnel-cost.entity.ts
@@ -13,7 +13,7 @@ export class PersonnelCost {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
-  @OneToOne(() => Expense, { cascade: true })
+  @OneToOne(() => Expense, { cascade: true, nullable: false })
   @JoinColumn()
   expense: Expense;
 

--- a/src/personnel-cost/entities/personnel-cost.entity.ts
+++ b/src/personnel-cost/entities/personnel-cost.entity.ts
@@ -1,4 +1,10 @@
-import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  OneToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 import { CostType } from '../enums/cost-type.enum';
 import { Expense } from 'src/expenses/entities/expense.entity';
 
@@ -7,18 +13,12 @@ export class PersonnelCost {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
-  @OneToOne(() => Expense, {cascade: true})
+  @OneToOne(() => Expense, { cascade: true })
   @JoinColumn()
   expense: Expense;
 
   @Column({ type: 'enum', enum: CostType })
   type: CostType;
-
-  @Column({ type: 'date', nullable: false })
-  date: Date;
-
-  @Column({ type: 'decimal', precision: 12, scale: 2, nullable: false })
-  value: string;
 
   @Column({ type: 'text' })
   description: string;

--- a/src/personnel-cost/entities/personnel-cost.entity.ts
+++ b/src/personnel-cost/entities/personnel-cost.entity.ts
@@ -1,10 +1,15 @@
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from 'typeorm';
 import { CostType } from '../enums/cost-type.enum';
+import { Expense } from 'src/expenses/entities/expense.entity';
 
 @Entity('personnel_cost')
 export class PersonnelCost {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @OneToOne(() => Expense, {cascade: true})
+  @JoinColumn()
+  expense: Expense;
 
   @Column({ type: 'enum', enum: CostType })
   type: CostType;

--- a/src/personnel-cost/personnel-cost.controller.ts
+++ b/src/personnel-cost/personnel-cost.controller.ts
@@ -19,6 +19,7 @@ import { PersonnelCostFilterDto } from './dtos/personnel-cost-filter.dto';
 import { UpdatePersonnelCostDto } from './dtos/update-personnel-cost.dto';
 
 @Roles(UserRole.ADMIN)
+@UsePipes(ValidationPipe)
 @Controller('personnel-cost')
 export class PersonnelCostController {
   constructor(private readonly personnelCostService: PersonnelCostService) {}
@@ -29,7 +30,6 @@ export class PersonnelCostController {
   }
 
   @Get()
-  @UsePipes(ValidationPipe)
   async findAll(@Query() filters: PersonnelCostFilterDto) {
     return await this.personnelCostService.findAll(filters);
   }

--- a/src/personnel-cost/personnel-cost.module.ts
+++ b/src/personnel-cost/personnel-cost.module.ts
@@ -3,9 +3,10 @@ import { PersonnelCostService } from './personnel-cost.service';
 import { PersonnelCostController } from './personnel-cost.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { PersonnelCost } from './entities/personnel-cost.entity';
+import { ExpensesModule } from 'src/expenses/expenses.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([PersonnelCost])],
+  imports: [TypeOrmModule.forFeature([PersonnelCost]), ExpensesModule],
   controllers: [PersonnelCostController],
   providers: [PersonnelCostService],
   exports: [PersonnelCostService],

--- a/src/personnel-cost/personnel-cost.service.ts
+++ b/src/personnel-cost/personnel-cost.service.ts
@@ -11,7 +11,6 @@ import { Repository } from 'typeorm';
 import { PersonnelCostFilterDto } from './dtos/personnel-cost-filter.dto';
 import { UpdatePersonnelCostDto } from './dtos/update-personnel-cost.dto';
 import { ExpenseType } from 'src/expenses/enums/expense-type.enum';
-import { log } from 'console';
 
 @Injectable()
 export class PersonnelCostService {
@@ -106,7 +105,7 @@ export class PersonnelCostService {
         );
       }
 
-      const personnelCostFormatted = {
+      const formattedPersonnelCost = {
         id: personnelCost.id,
         type: personnelCost.type,
         date: personnelCost.expense.date,
@@ -114,7 +113,7 @@ export class PersonnelCostService {
         description: personnelCost.description,
       };
 
-      return personnelCostFormatted;
+      return formattedPersonnelCost;
     } catch (error) {
       this.logger.error(error.message);
 

--- a/src/personnel-cost/personnel-cost.service.ts
+++ b/src/personnel-cost/personnel-cost.service.ts
@@ -66,12 +66,12 @@ export class PersonnelCostService {
       });
 
     try {
-      const [data, total] = await query
+      const [rows, total] = await query
         .skip((page - 1) * limit)
         .take(limit)
         .getManyAndCount();
 
-      const formattedData = data.map((item) => ({
+      const data = rows.map((item) => ({
         id: item.id,
         type: item.type,
         date: item.expense.date,
@@ -84,7 +84,7 @@ export class PersonnelCostService {
         page,
         limit,
         totalPages: Math.ceil(total / limit),
-        formattedData,
+        data,
       };
     } catch (error) {
       this.logger.error(error.message);

--- a/src/personnel-cost/personnel-cost.service.ts
+++ b/src/personnel-cost/personnel-cost.service.ts
@@ -11,6 +11,7 @@ import { Repository } from 'typeorm';
 import { PersonnelCostFilterDto } from './dtos/personnel-cost-filter.dto';
 import { UpdatePersonnelCostDto } from './dtos/update-personnel-cost.dto';
 import { ExpenseType } from 'src/expenses/enums/expense-type.enum';
+import { ExpensesService } from 'src/expenses/expenses.service';
 
 @Injectable()
 export class PersonnelCostService {
@@ -19,6 +20,7 @@ export class PersonnelCostService {
   constructor(
     @InjectRepository(PersonnelCost)
     private readonly personnelCostRepository: Repository<PersonnelCost>,
+    private readonly expensesService: ExpensesService,
   ) {}
 
   async register(registerPersonnelCostDto: RegisterPersonnelCostDto) {
@@ -165,6 +167,7 @@ export class PersonnelCostService {
     try {
       const personnelCost = await this.personnelCostRepository.findOne({
         where: { id },
+        relations: ['expense'],
       });
 
       if (!personnelCost) {
@@ -173,7 +176,7 @@ export class PersonnelCostService {
         );
       }
 
-      await this.personnelCostRepository.delete(id);
+      await this.expensesService.delete(personnelCost.expense.id);
       return { message: `Custo com pessoal id(${id}) deletado com sucesso` };
     } catch (error) {
       this.logger.error(error.message);

--- a/src/supplies/entities/supplies.entity.ts
+++ b/src/supplies/entities/supplies.entity.ts
@@ -14,7 +14,7 @@ export class Supplies {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
-  @OneToOne(() => Expense, { cascade: true })
+  @OneToOne(() => Expense, { cascade: true, nullable: false })
   @JoinColumn()
   expense: Expense;
 

--- a/src/supplies/entities/supplies.entity.ts
+++ b/src/supplies/entities/supplies.entity.ts
@@ -21,23 +21,17 @@ export class Supplies {
   @Column({ type: 'varchar', length: 100 })
   name: string;
 
-  @Column({ type: 'date' })
-  date: Date;
-
   @Column({ type: 'int' })
   quantity: number;
 
   @Column({ name: 'unit_price', type: 'decimal', precision: 10, scale: 2 })
   unitPrice: number;
 
-  @Column({ name: 'total_cost', type: 'decimal', precision: 10, scale: 2 })
-  totalCost: number;
-
   @BeforeInsert()
   @BeforeUpdate()
   calculateTotalCost() {
     if (this.quantity && this.unitPrice) {
-      this.totalCost = Number(this.quantity) * Number(this.unitPrice);
+      this.expense.value = Number(this.quantity) * Number(this.unitPrice);
     }
   }
 }

--- a/src/supplies/entities/supplies.entity.ts
+++ b/src/supplies/entities/supplies.entity.ts
@@ -14,7 +14,11 @@ export class Supplies {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
-  @OneToOne(() => Expense, { cascade: true, nullable: false })
+  @OneToOne(() => Expense, {
+    cascade: true,
+    onDelete: 'CASCADE',
+    nullable: false,
+  })
   @JoinColumn()
   expense: Expense;
 

--- a/src/supplies/entities/supplies.entity.ts
+++ b/src/supplies/entities/supplies.entity.ts
@@ -1,8 +1,11 @@
+import { Expense } from 'src/expenses/entities/expense.entity';
 import {
   BeforeInsert,
   BeforeUpdate,
   Column,
   Entity,
+  JoinColumn,
+  OneToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
 
@@ -10,6 +13,10 @@ import {
 export class Supplies {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @OneToOne(() => Expense, { cascade: true })
+  @JoinColumn()
+  expense: Expense;
 
   @Column({ type: 'varchar', length: 100 })
   name: string;

--- a/src/supplies/supplies.module.ts
+++ b/src/supplies/supplies.module.ts
@@ -3,9 +3,10 @@ import { SuppliesController } from './supplies.controller';
 import { SuppliesService } from './supplies.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Supplies } from './entities/supplies.entity';
+import { ExpensesModule } from 'src/expenses/expenses.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Supplies])],
+  imports: [TypeOrmModule.forFeature([Supplies]), ExpensesModule],
   controllers: [SuppliesController],
   providers: [SuppliesService],
 })

--- a/src/supplies/supplies.service.ts
+++ b/src/supplies/supplies.service.ts
@@ -153,7 +153,10 @@ export class SuppliesService {
         });
       }
 
-      return await this.suppliesRepository.save(supply);
+      await this.suppliesRepository.save(supply);
+      return {
+        message: `Custo com insumo id(${id}) atualizado com sucesso`,
+      };
     } catch (error) {
       this.logger.error(error.message);
 

--- a/src/supplies/supplies.service.ts
+++ b/src/supplies/supplies.service.ts
@@ -11,6 +11,7 @@ import { RegisterSuppliesDto } from './dtos/register-supplies.dto';
 import { FilterSuppliesDto } from './dtos/filter-supplies.dto';
 import { UpdateSuppliesDto } from './dtos/update-supplies.dto';
 import { ExpenseType } from 'src/expenses/enums/expense-type.enum';
+import { ExpensesService } from 'src/expenses/expenses.service';
 
 @Injectable()
 export class SuppliesService {
@@ -18,6 +19,7 @@ export class SuppliesService {
   constructor(
     @InjectRepository(Supplies)
     private readonly suppliesRepository: Repository<Supplies>,
+    private readonly expensesService: ExpensesService,
   ) {}
 
   async register(registerSuppliesDto: RegisterSuppliesDto) {
@@ -172,6 +174,7 @@ export class SuppliesService {
     try {
       const supply = await this.suppliesRepository.findOne({
         where: { id },
+        relations: ['expense'],
       });
 
       if (!supply) {
@@ -180,7 +183,7 @@ export class SuppliesService {
         );
       }
 
-      await this.suppliesRepository.delete(id);
+      await this.expensesService.delete(supply.expense.id);
       return { message: `Custo com insumo id(${id}) deletado com sucesso` };
     } catch (error) {
       this.logger.error(error.message);

--- a/src/supplies/supplies.service.ts
+++ b/src/supplies/supplies.service.ts
@@ -72,18 +72,18 @@ export class SuppliesService {
     if (maxTotal) query.andWhere('expense.value <= :maxTotal', { maxTotal });
 
     try {
-      const [data, total] = await query
+      const [rows, total] = await query
         .skip((page - 1) * limit)
         .take(limit)
         .getManyAndCount();
 
-      const formattedData = data.map((item) => ({
+      const data = rows.map((item) => ({
         id: item.id,
         name: item.name,
         date: item.expense.date,
         quantity: item.quantity,
         unitPrice: item.unitPrice,
-        value: item.expense.value,
+        totalCost: item.expense.value,
       }));
 
       return {
@@ -91,7 +91,7 @@ export class SuppliesService {
         page,
         limit,
         totalPages: Math.ceil(total / limit),
-        formattedData,
+        data,
       };
     } catch (error) {
       this.logger.error(error.message);
@@ -118,7 +118,7 @@ export class SuppliesService {
         date: supply.expense.date,
         quantity: supply.quantity,
         unitPrice: supply.unitPrice,
-        value: supply.expense.value,
+        totalCost: supply.expense.value,
       };
 
       return formattedSupply;

--- a/src/utility-cost/dtos/register-utility-cost.dto.ts
+++ b/src/utility-cost/dtos/register-utility-cost.dto.ts
@@ -3,9 +3,12 @@ import {
   IsDecimal,
   IsEnum,
   IsNotEmpty,
+  IsNumber,
   IsString,
+  Min,
 } from 'class-validator';
 import { CostType } from '../enums/cost-type.enum';
+import { Type } from 'class-transformer';
 
 export class RegisterUtilityCostDto {
   @IsEnum(CostType)
@@ -14,11 +17,13 @@ export class RegisterUtilityCostDto {
 
   @IsDateString()
   @IsNotEmpty()
-  date: string;
+  date: Date;
 
-  @IsDecimal({ decimal_digits: '2' })
+  @Type(() => Number)
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0)
   @IsNotEmpty()
-  value: string;
+  value: number;
 
   @IsString()
   @IsNotEmpty()

--- a/src/utility-cost/dtos/update-utility-cost.dto.ts
+++ b/src/utility-cost/dtos/update-utility-cost.dto.ts
@@ -1,11 +1,13 @@
 import {
   IsDateString,
-  IsDecimal,
   IsEnum,
+  IsNumber,
   IsOptional,
   IsString,
+  Min,
 } from 'class-validator';
 import { CostType } from '../enums/cost-type.enum';
+import { Type } from 'class-transformer';
 
 export class UpdateUtilityCostDto {
   @IsEnum(CostType)
@@ -14,11 +16,13 @@ export class UpdateUtilityCostDto {
 
   @IsDateString()
   @IsOptional()
-  date?: string;
+  date?: Date;
 
-  @IsDecimal({ decimal_digits: '2' })
+  @Type(() => Number)
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0)
   @IsOptional()
-  value?: string;
+  value?: number;
 
   @IsString()
   @IsOptional()

--- a/src/utility-cost/entities/utility-cost.entity.ts
+++ b/src/utility-cost/entities/utility-cost.entity.ts
@@ -13,7 +13,11 @@ export class UtilityCost {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
-  @OneToOne(() => Expense, { cascade: true, nullable: false })
+  @OneToOne(() => Expense, {
+    cascade: true,
+    onDelete: 'CASCADE',
+    nullable: false,
+  })
   @JoinColumn()
   expense: Expense;
 

--- a/src/utility-cost/entities/utility-cost.entity.ts
+++ b/src/utility-cost/entities/utility-cost.entity.ts
@@ -1,10 +1,21 @@
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  OneToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 import { CostType } from '../enums/cost-type.enum';
+import { Expense } from 'src/expenses/entities/expense.entity';
 
 @Entity('utility_cost')
 export class UtilityCost {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @OneToOne(() => Expense, { cascade: true })
+  @JoinColumn()
+  expense: Expense;
 
   @Column({ type: 'enum', enum: CostType })
   type: CostType;

--- a/src/utility-cost/entities/utility-cost.entity.ts
+++ b/src/utility-cost/entities/utility-cost.entity.ts
@@ -13,7 +13,7 @@ export class UtilityCost {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
-  @OneToOne(() => Expense, { cascade: true })
+  @OneToOne(() => Expense, { cascade: true, nullable: false })
   @JoinColumn()
   expense: Expense;
 

--- a/src/utility-cost/entities/utility-cost.entity.ts
+++ b/src/utility-cost/entities/utility-cost.entity.ts
@@ -20,12 +20,6 @@ export class UtilityCost {
   @Column({ type: 'enum', enum: CostType })
   type: CostType;
 
-  @Column({ type: 'date', nullable: false })
-  date: Date;
-
-  @Column({ type: 'decimal', precision: 12, scale: 2, nullable: false })
-  value: string;
-
   @Column({ type: 'text' })
   observations: string;
 }

--- a/src/utility-cost/utility-cost.controller.ts
+++ b/src/utility-cost/utility-cost.controller.ts
@@ -20,6 +20,7 @@ import { UtilityCostFilterDto } from './dtos/utility-cost-filter.dto';
 import { UpdateUtilityCostDto } from './dtos/update-utility-cost.dto';
 
 @Roles(UserRole.ADMIN)
+@UsePipes(ValidationPipe)
 @Controller('utility-cost')
 export class UtilityCostController {
   constructor(private readonly utilityCostService: UtilityCostService) {}
@@ -31,7 +32,6 @@ export class UtilityCostController {
   }
 
   @Get()
-  @UsePipes(ValidationPipe)
   async findAll(@Query() filters: UtilityCostFilterDto) {
     return await this.utilityCostService.findAll(filters);
   }
@@ -42,7 +42,6 @@ export class UtilityCostController {
   }
 
   @Put(':id')
-  @UsePipes(ValidationPipe)
   async update(
     @Param('id', new ParseUUIDPipe()) id: string,
     @Body() updateUtilityCostDto: UpdateUtilityCostDto,

--- a/src/utility-cost/utility-cost.module.ts
+++ b/src/utility-cost/utility-cost.module.ts
@@ -3,9 +3,10 @@ import { UtilityCostController } from './utility-cost.controller';
 import { UtilityCostService } from './utility-cost.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UtilityCost } from './entities/utility-cost.entity';
+import { ExpensesModule } from 'src/expenses/expenses.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([UtilityCost])],
+  imports: [TypeOrmModule.forFeature([UtilityCost]), ExpensesModule],
   controllers: [UtilityCostController],
   providers: [UtilityCostService],
 })

--- a/src/utility-cost/utility-cost.service.ts
+++ b/src/utility-cost/utility-cost.service.ts
@@ -10,6 +10,7 @@ import { UtilityCost } from './entities/utility-cost.entity';
 import { Repository } from 'typeorm';
 import { UtilityCostFilterDto } from './dtos/utility-cost-filter.dto';
 import { UpdateUtilityCostDto } from './dtos/update-utility-cost.dto';
+import { ExpenseType } from 'src/expenses/enums/expense-type.enum';
 
 @Injectable()
 export class UtilityCostService {
@@ -22,6 +23,11 @@ export class UtilityCostService {
   async register(registerUtilityCostDto: RegisterUtilityCostDto) {
     try {
       const utilityCost = this.utilityCostRepository.create({
+        expense: {
+          date: registerUtilityCostDto.date,
+          value: registerUtilityCostDto.value,
+          category: ExpenseType.UTILITY,
+        },
         ...registerUtilityCostDto,
       });
 
@@ -44,16 +50,18 @@ export class UtilityCostService {
       limit = 10,
     } = filters;
 
-    const query = this.utilityCostRepository.createQueryBuilder('cost');
+    const query = this.utilityCostRepository
+      .createQueryBuilder('cost')
+      .leftJoinAndSelect('cost.expense', 'expense');
 
     if (type) query.andWhere('cost.type = :type', { type });
-    if (dateFrom) query.andWhere('cost.date >= :dateFrom', { dateFrom });
-    if (dateTo) query.andWhere('cost.date <= :dateTo', { dateTo });
-    if (minValue) query.andWhere('cost.value >= :minValue', { minValue });
-    if (maxValue) query.andWhere('cost.value <= :maxValue', { maxValue });
+    if (dateFrom) query.andWhere('expense.date >= :dateFrom', { dateFrom });
+    if (dateTo) query.andWhere('expense.date <= :dateTo', { dateTo });
+    if (minValue) query.andWhere('expense.value >= :minValue', { minValue });
+    if (maxValue) query.andWhere('expense.value <= :maxValue', { maxValue });
     if (observations)
-      query.andWhere('cost.observations ILIKE :description', {
-        description: `%${observations}%`,
+      query.andWhere('cost.observations ILIKE :observations', {
+        observations: `%${observations}%`,
       });
 
     try {
@@ -62,12 +70,20 @@ export class UtilityCostService {
         .take(limit)
         .getManyAndCount();
 
+      const formattedData = data.map((item) => ({
+        id: item.id,
+        type: item.type,
+        date: item.expense.date,
+        value: item.expense.value,
+        observations: item.observations,
+      }));
+
       return {
         total,
         page,
         limit,
         totalPages: Math.ceil(total / limit),
-        data,
+        formattedData,
       };
     } catch (error) {
       this.logger.error(error.message);
@@ -79,6 +95,7 @@ export class UtilityCostService {
     try {
       const utilityCost = await this.utilityCostRepository.findOne({
         where: { id },
+        relations: ['expense'],
       });
 
       if (!utilityCost) {
@@ -87,7 +104,15 @@ export class UtilityCostService {
         );
       }
 
-      return utilityCost;
+      const formattedUtilityCost = {
+        id: utilityCost.id,
+        type: utilityCost.type,
+        date: utilityCost.expense.date,
+        value: utilityCost.expense.value,
+        observations: utilityCost.observations,
+      };
+
+      return formattedUtilityCost;
     } catch (error) {
       this.logger.error(error.message);
 
@@ -101,9 +126,9 @@ export class UtilityCostService {
 
   async update(id: string, updateUtilityCostDto: UpdateUtilityCostDto) {
     try {
-      const utilityCost = await this.utilityCostRepository.preload({
-        id,
-        ...updateUtilityCostDto,
+      const utilityCost = await this.utilityCostRepository.findOne({
+        where: { id },
+        relations: ['expense'],
       });
 
       if (!utilityCost) {
@@ -112,7 +137,18 @@ export class UtilityCostService {
         );
       }
 
-      return await this.utilityCostRepository.save(utilityCost);
+      Object.assign(utilityCost, updateUtilityCostDto);
+      if (updateUtilityCostDto.date || updateUtilityCostDto.value) {
+        Object.assign(utilityCost.expense, {
+          date: updateUtilityCostDto.date,
+          value: updateUtilityCostDto.value,
+        });
+      }
+
+      await this.utilityCostRepository.save(utilityCost);
+      return {
+        message: `Custo com utilidade id(${id}) atualizado com sucesso`,
+      };
     } catch (error) {
       this.logger.error(error.message);
 
@@ -128,6 +164,7 @@ export class UtilityCostService {
     try {
       const utilityCost = await this.utilityCostRepository.findOne({
         where: { id },
+        relations: ['expense']
       });
 
       if (!utilityCost) {
@@ -136,7 +173,7 @@ export class UtilityCostService {
         );
       }
 
-      await this.utilityCostRepository.delete(utilityCost);
+      await this.utilityCostRepository.delete(id);
       return { message: `Custo com utilidade id(${id}) deletado com sucesso` };
     } catch (error) {
       this.logger.error(error.message);

--- a/src/utility-cost/utility-cost.service.ts
+++ b/src/utility-cost/utility-cost.service.ts
@@ -65,12 +65,12 @@ export class UtilityCostService {
       });
 
     try {
-      const [data, total] = await query
+      const [rows, total] = await query
         .skip((page - 1) * limit)
         .take(limit)
         .getManyAndCount();
 
-      const formattedData = data.map((item) => ({
+      const data = rows.map((item) => ({
         id: item.id,
         type: item.type,
         date: item.expense.date,
@@ -83,7 +83,7 @@ export class UtilityCostService {
         page,
         limit,
         totalPages: Math.ceil(total / limit),
-        formattedData,
+        data,
       };
     } catch (error) {
       this.logger.error(error.message);
@@ -164,7 +164,7 @@ export class UtilityCostService {
     try {
       const utilityCost = await this.utilityCostRepository.findOne({
         where: { id },
-        relations: ['expense']
+        relations: ['expense'],
       });
 
       if (!utilityCost) {

--- a/src/utility-cost/utility-cost.service.ts
+++ b/src/utility-cost/utility-cost.service.ts
@@ -11,6 +11,7 @@ import { Repository } from 'typeorm';
 import { UtilityCostFilterDto } from './dtos/utility-cost-filter.dto';
 import { UpdateUtilityCostDto } from './dtos/update-utility-cost.dto';
 import { ExpenseType } from 'src/expenses/enums/expense-type.enum';
+import { ExpensesService } from 'src/expenses/expenses.service';
 
 @Injectable()
 export class UtilityCostService {
@@ -18,6 +19,7 @@ export class UtilityCostService {
   constructor(
     @InjectRepository(UtilityCost)
     private readonly utilityCostRepository: Repository<UtilityCost>,
+    private readonly expensesService: ExpensesService,
   ) {}
 
   async register(registerUtilityCostDto: RegisterUtilityCostDto) {
@@ -173,7 +175,7 @@ export class UtilityCostService {
         );
       }
 
-      await this.utilityCostRepository.delete(id);
+      await this.expensesService.delete(utilityCost.expense.id);
       return { message: `Custo com utilidade id(${id}) deletado com sucesso` };
     } catch (error) {
       this.logger.error(error.message);


### PR DESCRIPTION
## Contexto
Cada categoria de despesa possuía sua própria estrutura de dados individualmente, o que posteriormente iria dificultar análises e relatórios. Além disso alguns **_DTOs_** não estavam padronizados em relação aos valores decimais.

## Alterações
- Criação da tabela `expenses` para centralizar as despesas.
- Entidades refatoradas:

  - `PersonnelCost`
  - `UtilityCost`
  - `Supplies`
  - `OperationalCost`
 
> Em cada entidade foi adicionado o seguinte campo para refletir um relacionamento `OneToOne` com `Expense`
```ts
@OneToOne(() => Expense, {
  cascade: true,
  onDelete: 'CASCADE',
  nullable: false,
})
@JoinColumn()
expense: Expense;
```
- Atualizados os **_Services_** e **_DTOs_** para refletir as novas estruturas

> Valores decimais nos **_DTOs_** padronizados com as seguintes validações
```ts
@Type(() => Number)
@IsNumber({ maxDecimalPlaces: 2 })
@Min(0)
```
## Observações
- As migrações precisam ser executadas com o comando `npm run migration:run` para criar a tabela `expenses` e suas _**FKs**_.  
- Pode ser necessário utilizar o comando `npm run migration:revert` para reverter migrações anteriores e daí executar as alterações.