### PR TITLE
feature: implementação dos endpoints de análise de receitas e relatório financeiro

### DIFF
--- a/src/expenses/expenses.controller.ts
+++ b/src/expenses/expenses.controller.ts
@@ -18,7 +18,7 @@ export class ExpensesController {
   }
 
   @Get('/daily')
-  async getGroupedByDay() {
-    return await this.expensesService.getDaily();
+  async getGroupedByDay(@Query() filters: ExpensesFilter) {
+    return await this.expensesService.getDaily(filters);
   }
 }

--- a/src/expenses/expenses.service.ts
+++ b/src/expenses/expenses.service.ts
@@ -100,7 +100,14 @@ export class ExpensesService {
         .orderBy('date', 'DESC')
         .getRawMany();
 
-      return dailyExpenses;
+      return dailyExpenses.map((e) => ({
+        date: e.date,
+        total: Number(e.total),
+        personnel: Number(e.personnel),
+        utility: Number(e.utility),
+        supplies: Number(e.supplies),
+        operational: Number(e.operational),
+      }));
     } catch (error) {
       this.logger.error(error.message);
 

--- a/src/expenses/expenses.service.ts
+++ b/src/expenses/expenses.service.ts
@@ -8,7 +8,6 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Expense } from './entities/expense.entity';
 import { Repository } from 'typeorm';
 import { ExpensesFilter } from './dtos/expenses-filter.dto';
-import { ExpenseType } from './enums/expense-type.enum';
 import { ComparePeriodsDto } from './dtos/compare-periods.dto';
 
 @Injectable()
@@ -18,8 +17,6 @@ export class ExpensesService {
     @InjectRepository(Expense)
     private readonly expenseRepository: Repository<Expense>,
   ) {}
-
-  private format = (value: number) => Number(value.toFixed(2));
 
   async getGrouped(filters: ExpensesFilter) {
     const query = this.expenseRepository.createQueryBuilder('expense');

--- a/src/expenses/expenses.service.ts
+++ b/src/expenses/expenses.service.ts
@@ -81,7 +81,8 @@ export class ExpensesService {
 
     try {
       const dailyExpenses = await query
-        .select('expense.date', 'date')
+        .select(`to_char(expense.date, 'YYYY-MM-DD')`, 'date')
+        .addSelect('COALESCE(SUM(expense.value), 0)', 'total')
         .addSelect(
           `COALESCE(SUM(expense.value) FILTER (WHERE expense.category = 'PERSONNEL'), 0)`,
           'personnel',
@@ -98,7 +99,7 @@ export class ExpensesService {
           `COALESCE(SUM(expense.value) FILTER (WHERE expense.category = 'OPERATIONAL'),0)`,
           'operational',
         )
-        .groupBy('expense.date')
+        .groupBy(`to_char(expense.date, 'YYYY-MM-DD')`)
         .orderBy('date', 'DESC')
         .getRawMany();
 

--- a/src/expenses/expenses.service.ts
+++ b/src/expenses/expenses.service.ts
@@ -72,10 +72,15 @@ export class ExpensesService {
     }
   }
 
-  async getDaily() {
+  async getDaily(filters: ExpensesFilter) {
+    const query = this.expenseRepository.createQueryBuilder('expense');
+    const { dateFrom, dateTo } = filters;
+
+    if (dateFrom) query.andWhere('expense.date >= :dateFrom', { dateFrom });
+    if (dateTo) query.andWhere('expense.date <= :dateTo', { dateTo });
+
     try {
-      const dailyExpenses = await this.expenseRepository
-        .createQueryBuilder('expense')
+      const dailyExpenses = await query
         .select('expense.date', 'date')
         .addSelect(
           `COALESCE(SUM(expense.value) FILTER (WHERE expense.category = 'PERSONNEL'), 0)`,

--- a/src/financial-report/dtos/compare-periods-dto.ts
+++ b/src/financial-report/dtos/compare-periods-dto.ts
@@ -1,0 +1,11 @@
+import { IsString, Matches } from 'class-validator';
+
+export class ComparePeriodsDto {
+  @IsString()
+  @Matches(/^\d{4}-(0[1-9]|1[0-2])$/)
+  periodOne: string;
+
+  @IsString()
+  @Matches(/^\d{4}-(0[1-9]|1[0-2])$/)
+  periodTwo: string;
+}

--- a/src/financial-report/dtos/financial-report-filter.dto.ts
+++ b/src/financial-report/dtos/financial-report-filter.dto.ts
@@ -3,12 +3,10 @@ import { Type } from 'class-transformer';
 
 export class FinancialReportFilterDto {
   @IsOptional()
-  @Type(() => Date)
   @IsDateString()
   dateFrom?: Date;
 
   @IsOptional()
-  @Type(() => Date)
   @IsDateString()
   dateTo?: Date;
 }

--- a/src/financial-report/financial-report.controller.ts
+++ b/src/financial-report/financial-report.controller.ts
@@ -7,6 +7,7 @@ import {
 } from '@nestjs/common';
 import { FinancialReportFilterDto } from './dtos/financial-report-filter.dto';
 import { FinancialReportService } from './financial-report.service';
+import { ComparePeriodsDto } from './dtos/compare-periods-dto';
 
 @Controller('financial-report')
 @UsePipes(ValidationPipe)
@@ -28,5 +29,10 @@ export class FinancialReportController {
   @Get('/daily')
   async getDaily(@Query() filters: FinancialReportFilterDto) {
     return await this.financialReportService.getDaily(filters);
+  }
+
+  @Get('/compare')
+  async compareMonths(@Query() dto: ComparePeriodsDto) {
+    return await this.financialReportService.compareByPeriod(dto);
   }
 }

--- a/src/financial-report/financial-report.controller.ts
+++ b/src/financial-report/financial-report.controller.ts
@@ -24,4 +24,9 @@ export class FinancialReportController {
   async getDetailedReport(@Query() filters: FinancialReportFilterDto) {
     return await this.financialReportService.getDetailedReport(filters);
   }
+
+  @Get('/daily')
+  async getDaily(@Query() filters: FinancialReportFilterDto) {
+    return await this.financialReportService.getDaily(filters);
+  }
 }

--- a/src/financial-report/financial-report.service.ts
+++ b/src/financial-report/financial-report.service.ts
@@ -8,6 +8,7 @@ import { ReceivesService } from '../receives/receives.service';
 import { ProductionsService } from '../productions/productions.service';
 import { FinancialReportFilterDto } from './dtos/financial-report-filter.dto';
 import { Receive } from 'src/receives/entities/receive.entity';
+import { ComparePeriodsDto } from './dtos/compare-periods-dto';
 
 @Injectable()
 export class FinancialReportService {
@@ -123,5 +124,36 @@ export class FinancialReportService {
     const merged = this.mergeFinancialData(dailyExpenses, dailyReceives);
 
     return merged;
+  }
+
+  private parsePeriod(period: String) {
+    const [year, month] = period.split('-').map(Number);
+
+    const dateFrom = new Date(year, month - 1, 1);
+    const dateTo = new Date(year, month, 0);
+
+    return { dateFrom, dateTo };
+  }
+
+  async compareByPeriod(dto: ComparePeriodsDto) {
+    const { periodOne, periodTwo } = dto;
+
+    const monthOne = this.parsePeriod(periodOne);
+    const monthTwo = this.parsePeriod(periodTwo);
+
+    const monthOneData = await this.getOverview({
+      dateFrom: monthOne.dateFrom,
+      dateTo: monthOne.dateTo,
+    });
+
+    const monthTwoData = await this.getOverview({
+      dateFrom: monthTwo.dateFrom,
+      dateTo: monthTwo.dateTo,
+    });
+
+    return {
+      monthOneData,
+      monthTwoData,
+    };
   }
 }

--- a/src/financial-report/financial-report.service.ts
+++ b/src/financial-report/financial-report.service.ts
@@ -71,12 +71,12 @@ export class FinancialReportService {
     const totalProduction = totalLocalProduction + totalProducersProduction;
 
     return {
-      personnelCosts: Number(expensesData.categories.PERSONNEL.toFixed(2)),
+      personnel: Number(expensesData.categories.PERSONNEL.toFixed(2)),
+      utility: Number(expensesData.categories.UTILITY.toFixed(2)),
       supplies: Number(expensesData.categories.SUPPLIES.toFixed(2)),
-      utilities: Number(expensesData.categories.UTILITY.toFixed(2)),
       operational: Number(expensesData.categories.OPERATIONAL.toFixed(2)),
       localProduction: Number(totalLocalProduction.toFixed(2)),
-      producersProduction: Number(totalProducersProduction.toFixed(2)),
+      producerProduction: Number(totalProducersProduction.toFixed(2)),
       totalProduction: Number(totalProduction.toFixed(2)),
     };
   }

--- a/src/financial-report/financial-report.service.ts
+++ b/src/financial-report/financial-report.service.ts
@@ -7,6 +7,7 @@ import { ExpensesService } from '../expenses/expenses.service';
 import { ReceivesService } from '../receives/receives.service';
 import { ProductionsService } from '../productions/productions.service';
 import { FinancialReportFilterDto } from './dtos/financial-report-filter.dto';
+import { Receive } from 'src/receives/entities/receive.entity';
 
 @Injectable()
 export class FinancialReportService {
@@ -48,40 +49,79 @@ export class FinancialReportService {
   }
 
   async getDetailedReport(filters: FinancialReportFilterDto) {
-    const expensesData = await this.expensesService.getGrouped({
-      dateFrom: filters.dateFrom,
-      dateTo: filters.dateTo,
-    });
+    try {
+      const expensesData = await this.expensesService.getGrouped({
+        dateFrom: filters.dateFrom,
+        dateTo: filters.dateTo,
+      });
 
-    const productionsData = await this.productionsService.getDaily({
-      dateFrom: filters.dateFrom,
-      dateTo: filters.dateTo,
-      page: 1,
-      limit: 999999,
-    });
+      const productionsData = await this.productionsService.getDaily({
+        dateFrom: filters.dateFrom,
+        dateTo: filters.dateTo,
+        page: 1,
+        limit: 999999,
+      });
 
-    let totalLocalProduction = 0;
-    let totalProducersProduction = 0;
+      let totalLocalProduction = 0;
+      let totalProducersProduction = 0;
 
-    productionsData.data.forEach((day: any) => {
-      totalLocalProduction += Number(day.totalQuantity || 0);
-      totalProducersProduction += Number(day.totalProducers || 0);
-    });
+      productionsData.data.forEach((day: any) => {
+        totalLocalProduction += Number(day.totalQuantity || 0);
+        totalProducersProduction += Number(day.totalProducers || 0);
+      });
 
-    const totalProduction = totalLocalProduction + totalProducersProduction;
+      const totalProduction = totalLocalProduction + totalProducersProduction;
 
-    return {
-      personnel: Number(expensesData.categories.PERSONNEL.toFixed(2)),
-      utility: Number(expensesData.categories.UTILITY.toFixed(2)),
-      supplies: Number(expensesData.categories.SUPPLIES.toFixed(2)),
-      operational: Number(expensesData.categories.OPERATIONAL.toFixed(2)),
-      localProduction: Number(totalLocalProduction.toFixed(2)),
-      producerProduction: Number(totalProducersProduction.toFixed(2)),
-      totalProduction: Number(totalProduction.toFixed(2)),
-    };
+      return {
+        personnel: Number(expensesData.categories.PERSONNEL.toFixed(2)),
+        utility: Number(expensesData.categories.UTILITY.toFixed(2)),
+        supplies: Number(expensesData.categories.SUPPLIES.toFixed(2)),
+        operational: Number(expensesData.categories.OPERATIONAL.toFixed(2)),
+        localProduction: Number(totalLocalProduction.toFixed(2)),
+        producerProduction: Number(totalProducersProduction.toFixed(2)),
+        totalProduction: Number(totalProduction.toFixed(2)),
+      };
+    } catch (error) {
+      this.logger.error(error.message);
+      throw new InternalServerErrorException();
+    }
   }
-  catch(error) {
-    this.logger.error(error.message);
-    throw new InternalServerErrorException();
+
+  private mergeFinancialData(expenses: any[], receives: Receive[]) {
+    const map = new Map();
+
+    expenses.forEach((d) => {
+      const existente = map.get(d.date) || {
+        date: d.date,
+        expenses: 0,
+        receives: 0,
+      };
+
+      existente.expenses += Number(d.total) || 0;
+      map.set(d.date, existente);
+    });
+
+    receives.forEach((r) => {
+      const existente = map.get(r.date) || {
+        date: r.date,
+        expenses: 0,
+        receives: 0,
+      };
+
+      existente.receives += Number(r.totalPrice) || 0;
+      map.set(r.date, existente);
+    });
+
+    return Array.from(map.values()).sort(
+      (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
+    );
+  }
+
+  async getDaily(filters: FinancialReportFilterDto) {
+    const dailyExpenses = await this.expensesService.getDaily(filters);
+    const dailyReceives = (await this.receivesService.findAll(filters)).data;
+    const merged = this.mergeFinancialData(dailyExpenses, dailyReceives);
+
+    return merged;
   }
 }

--- a/src/financial-report/financial-report.service.ts
+++ b/src/financial-report/financial-report.service.ts
@@ -25,16 +25,14 @@ export class FinancialReportService {
         dateTo: filters.dateTo,
       });
 
-      const receivesData = await this.receivesService.findAll({
+      const receivesData = await this.receivesService.getTotal({
         dateFrom: filters.dateFrom,
         dateTo: filters.dateTo,
-        page: 1,
-        limit: 1,
       });
 
       const totalExpenses = Number(expensesData.total.toFixed(2));
 
-      const totalReceives = Number(receivesData.monthly);
+      const totalReceives = Number(receivesData.total);
 
       const periodResult = Number((totalReceives - totalExpenses).toFixed(2));
 

--- a/src/productions/local/dtos/filter-period-local-production.dto.ts
+++ b/src/productions/local/dtos/filter-period-local-production.dto.ts
@@ -1,0 +1,11 @@
+import { IsDateString, IsOptional } from 'class-validator';
+
+export class LocalProductionPeriodFilter {
+  @IsOptional()
+  @IsDateString()
+  dateFrom?: Date;
+
+  @IsOptional()
+  @IsDateString()
+  dateTo?: Date;
+}

--- a/src/productions/local/local-production.controller.ts
+++ b/src/productions/local/local-production.controller.ts
@@ -17,6 +17,7 @@ import { Roles } from 'src/common/decorators/roles.decorator';
 import { UserRole } from 'src/users/enums/user-role.enum';
 import { FilterLocalProductionDto } from './dtos/filter-local-production.dto';
 import { UpdateLocalProductionDto } from './dtos/update-local-production.dto';
+import { LocalProductionPeriodFilter } from './dtos/filter-period-local-production.dto';
 
 @Roles(UserRole.ADMIN)
 @UsePipes(ValidationPipe)
@@ -54,5 +55,10 @@ export class LocalProductionController {
   @Delete('/:id')
   async delete(@Param('id', new ParseUUIDPipe()) id: string) {
     return await this.localProductionService.delete(id);
+  }
+
+  @Get('/grouped')
+  async getGrouped(@Query() filters: LocalProductionPeriodFilter) {
+    return await this.localProductionService.getGrouped(filters);
   }
 }

--- a/src/productions/productions.controller.ts
+++ b/src/productions/productions.controller.ts
@@ -13,4 +13,9 @@ export class ProductionsController {
   async getDailyProduction(@Query() filters: GetDailyProductionDto) {
     return await this.productionsService.getDaily(filters);
   }
+
+  @Get('/monthly')
+  async getGroupedByMonth() {
+    return await this.productionsService.getGroupedByMonth();
+  }
 }

--- a/src/receives/receives.service.ts
+++ b/src/receives/receives.service.ts
@@ -345,4 +345,23 @@ export class ReceivesService {
 
     return Number(average.total).toFixed(2);
   }
+
+  async getTotal(filters: ReceivesFilterDto) {
+    const query = this.receiveRepository.createQueryBuilder('receive');
+    const { dateFrom, dateTo } = filters;
+
+    if (dateFrom) query.andWhere('receive.date >= :dateFrom', { dateFrom });
+    if (dateTo) query.andWhere('receive.date <= :dateTo', { dateTo });
+
+    try {
+      const receivesSum = await query
+        .select('SUM(receive.totalPrice)', 'total')
+        .getRawOne();
+
+      return receivesSum;
+    } catch (error) {
+      this.logger.error(error.message);
+      throw new InternalServerErrorException(error.message);
+    }
+  }
 }


### PR DESCRIPTION
## Contexto
Endpoints e métodos desenvolvidos para dar suporte à equipe de Front-end na implementação dos gráficos e consultas.

## Endpoints

### Análise de Despesas
#### 1. Despesas por Dia
```bash
GET /expenses/daily
```
**Utilização:**
- Line Chart — Exibe a variação das despesas, total e por categoria, ao longo do tempo.

  - `?dateFrom=2025-11-24` `?dateTo=2025-12-01`

#### 2. Distribuição Geral das Despesas
```bash
GET /expenses
```
**Utilização:**
- Pie Chart — Mostra a distribuição das despesas por categoria no período selecionado.

  - `?dateFrom=2025-11-24` `?dateTo=2025-12-01`

#### 3. Comparação entre meses de despesas
```bash
GET /expenses/compare
```
**Utilização:**
- Bar Chart — Mostra a comparação entre dois meses de todas as despesas, deve receber os parâmetros como mês-ano.

  - `?periodOne=2025-11&periodTwo=2025-12`

### Análise de Receitas
#### 1. Produção local total
```bash
GET  /productions/local/grouped
```
**Utilização:**
- Pie Chart — Mostra a distribuição da que foi para o tanque e o que foi para consumo interno da produção local.

  - `?dateFrom=2025-11-24` `?dateTo=2025-12-01`

#### 2. Produção total agrupada por mês
```bash
GET /productions/monthly
```
**Utilização:**
- Bar Chart — Mostra a produção total, local e dos produtores agrupadas por mês.

### Relatório Financeiro
#### 1. Financeiro por Dia
```bash
GET /financial-report/daily
```
**Utilização:**
- Line Chart — Exibe a variação das receitas e despesas ao longo do tempo.

  - `?dateFrom=2025-11-24` `?dateTo=2025-12-01`

#### 2. Comparação de financeiro
```bash
GET /financial-report/compare
```
**Utilização:**
- Bar Chart — Mostra a comparação entre dois meses do financeiro, deve receber os parâmetros como mês-ano.

  - `?periodOne=2025-11&periodTwo=2025-12`


